### PR TITLE
fix a bug where listings not refreshing when deleting a bookmark in "all bookmarks popup"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -330,7 +330,10 @@ function App() {
         ></MyItems>
       )}
       {isMyBookmarksVisible && (
-        <MyBookmarks close={() => setIsMyBookmarksVisible(false)}></MyBookmarks>
+        <MyBookmarks
+          close={() => setIsMyBookmarksVisible(false)}
+          refresh={FetchProducts}
+        ></MyBookmarks>
       )}
     </>
   );

--- a/src/components/MyBookmarks.tsx
+++ b/src/components/MyBookmarks.tsx
@@ -12,6 +12,7 @@ import { faTrash } from "@fortawesome/free-solid-svg-icons";
 
 interface MyBookmarksProps {
   close: () => void;
+  refresh: () => void;
 }
 
 type Bookmark = {
@@ -131,6 +132,7 @@ function MyBookmarks(props: MyBookmarksProps) {
         }
       );
       FetchBookmarks();
+      props.refresh();
     } catch (error) {
       alert(error);
     }


### PR DESCRIPTION
Fix: All listings not refreshing when deleting a bookmark